### PR TITLE
do not pre-generate so we can do 1M+ events (instead of for loop)

### DIFF
--- a/events/billing.go
+++ b/events/billing.go
@@ -21,6 +21,7 @@ var (
 )
 
 func init() {
+	// Pre-create some products
 	for i := 0; i < 100; i++ {
 		products = append(products, &fakes.BillingProduct{
 			Id:       uuid.NewV4().String(),
@@ -31,11 +32,9 @@ func init() {
 	}
 }
 
-func GenerateBillingEvents(count int) []*fakes.Event {
-	events := make([]*fakes.Event, 0)
-
+func GenerateBillingEvents(count int, generateChan chan *fakes.Event) {
 	for i := 0; i < count; i++ {
-		events = append(events, &fakes.Event{
+		generateChan <- &fakes.Event{
 			Type:          fakes.EventType_EVENT_TYPE_BILLING,
 			TimestampNano: time.Now().UTC().UnixNano(),
 			RequestId:     uuid.NewV4().String(),
@@ -43,10 +42,8 @@ func GenerateBillingEvents(count int) []*fakes.Event {
 			Event: &fakes.Event_Billing{
 				Billing: newBillingEvent(),
 			},
-		})
+		}
 	}
-
-	return events
 }
 
 func newBillingEvent() *fakes.Billing {

--- a/events/events.go
+++ b/events/events.go
@@ -3,22 +3,23 @@ package events
 import (
 	"fmt"
 
-	"github.com/batchcorp/event-generator/cli"
 	"github.com/batchcorp/schemas/build/go/events/fakes"
 	"github.com/pkg/errors"
+
+	"github.com/batchcorp/event-generator/cli"
 )
 
-func GenerateEvents(params *cli.Params) ([]*fakes.Event, error) {
-	data := make([]*fakes.Event, 0)
+func GenerateEvents(params *cli.Params) (chan *fakes.Event, error) {
+	generateChan := make(chan *fakes.Event, 1000)
 
 	switch params.Type {
 	case string(TopicTestType):
 		//data = GenerateTopicTestEvents(params.Count, params.TopicPrefix, params.TopicReplicas, params.TopicPartitions)
 		return nil, errors.New("not implemented")
 	case string(SearchEventType):
-		data = GenerateSearchEvents(params.Count)
+		go GenerateSearchEvents(params.Count, generateChan)
 	case string(BillingEventType):
-		data = GenerateBillingEvents(params.Count)
+		go GenerateBillingEvents(params.Count, generateChan)
 	case string(MonitoringEventType):
 		return nil, errors.New("not implemented")
 	case string(AuditEventType):
@@ -29,5 +30,5 @@ func GenerateEvents(params *cli.Params) ([]*fakes.Event, error) {
 		return nil, fmt.Errorf("unknown event type '%s'", params.Type)
 	}
 
-	return data, nil
+	return generateChan, nil
 }

--- a/events/search.go
+++ b/events/search.go
@@ -8,8 +8,9 @@ import (
 	"github.com/brianvoe/gofakeit/v6"
 	uuid "github.com/satori/go.uuid"
 
-	"github.com/batchcorp/event-generator/generator"
 	"github.com/batchcorp/schemas/build/go/events/fakes"
+
+	"github.com/batchcorp/event-generator/generator"
 )
 
 var (
@@ -39,11 +40,9 @@ var (
 	}
 )
 
-func GenerateSearchEvents(count int) []*fakes.Event {
-	events := make([]*fakes.Event, 0)
-
+func GenerateSearchEvents(count int, generateChan chan *fakes.Event) {
 	for i := 0; i < count; i++ {
-		events = append(events, &fakes.Event{
+		generateChan <- &fakes.Event{
 			Type:          fakes.EventType_EVENT_TYPE_SEARCH,
 			TimestampNano: time.Now().UTC().UnixNano(),
 			RequestId:     uuid.NewV4().String(),
@@ -51,10 +50,8 @@ func GenerateSearchEvents(count int) []*fakes.Event {
 			Event: &fakes.Event_Search{
 				Search: newSearchEvent(),
 			},
-		})
+		}
 	}
-
-	return events
 }
 
 func newSearchEvent() *fakes.Search {


### PR DESCRIPTION
Got annoyed that I couldn't do 1M+ events at the same time as it was doing pre-generation. We now generate a batch right before it's sent out. No idea why I didn't do it this way from the start. Woops.

@blinktag @brainsnail 